### PR TITLE
Move to the github.com/qpliu/qrencode-go/qrencode package

### DIFF
--- a/totp.go
+++ b/totp.go
@@ -48,9 +48,15 @@ func BarcodeImage(label string, secretkey []byte, opt *Options) ([]byte, error) 
 		return nil, err
 	}
 
-	buf := bytes.NewBuffer([]byte{})
-	err = png.Encode(buf, c.Image(8))
-	return buf.Bytes(), err
+	var buf bytes.Buffer
+
+	err = png.Encode(&buf, c.Image(8))
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }
 
 // Options contains the different configurable values for a given TOTP

--- a/totp.go
+++ b/totp.go
@@ -4,7 +4,6 @@
 package totp
 
 import (
-	"code.google.com/p/rsc/qr"
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base32"
@@ -13,6 +12,11 @@ import (
 	"net/url"
 	"strconv"
 	"time"
+
+	"bytes"
+	"image/png"
+
+	qr "github.com/qpliu/qrencode-go/qrencode"
 )
 
 // BarcodeImage creates a QR code for use with Google Authenticator (GA).
@@ -38,13 +42,15 @@ func BarcodeImage(label string, secretkey []byte, opt *Options) ([]byte, error) 
 
 	u.RawQuery = params.Encode()
 
-	c, err := qr.Encode(u.String(), qr.M)
+	c, err := qr.Encode(u.String(), qr.ECLevelM)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return c.PNG(), nil
+	buf := bytes.NewBuffer([]byte{})
+	err = png.Encode(buf, c.Image(8))
+	return buf.Bytes(), err
 }
 
 // Options contains the different configurable values for a given TOTP

--- a/totp.go
+++ b/totp.go
@@ -49,8 +49,14 @@ func BarcodeImage(label string, secretkey []byte, opt *Options) ([]byte, error) 
 	}
 
 	buf := bytes.NewBuffer([]byte{})
+
 	err = png.Encode(buf, c.Image(8))
-	return buf.Bytes(), err
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }
 
 // Options contains the different configurable values for a given TOTP


### PR DESCRIPTION
This package is the most used and starred on gosearch which
is as good a proxy as I could think of for likelihood of support
going forward.

I test generated a png and verified that it was importable into
google authenticator as well as the popular DUO authenticator.

It's a little more work in our code to generate the barcode but not that much really.

Fixes #1
