### PR TITLE
trim base32 encoded string paddings from right side, google authentic…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+.idea

--- a/totp.go
+++ b/totp.go
@@ -17,6 +17,7 @@ import (
 	"image/png"
 
 	qr "github.com/qpliu/qrencode-go/qrencode"
+	"strings"
 )
 
 // BarcodeImage creates a QR code for use with Google Authenticator (GA).
@@ -35,7 +36,7 @@ func BarcodeImage(label string, secretkey []byte, opt *Options) ([]byte, error) 
 	}
 
 	params := url.Values{
-		"secret": {base32.StdEncoding.EncodeToString(secretkey)},
+		"secret": {strings.TrimRight(base32.StdEncoding.EncodeToString(secretkey), "=")},
 		"digits": {strconv.Itoa(int(opt.Digits))},
 		"period": {strconv.Itoa(int(opt.TimeStep / time.Second))},
 	}


### PR DESCRIPTION
According to google authenticator spec the padding specified in RFC 3548 section 2.2 is not required and should be omitted.
https://github.com/google/google-authenticator/wiki/Key-Uri-Format#secret